### PR TITLE
feat: Set HttpOnly Cookie, enable CORS, and use fetch for API calls

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -5,9 +5,16 @@ const app = express()
 const port = 3000
 const routes = require('./routes')
 const errorHandler = require('./middleware/error-handler')
+const cors = require('cors')
 
 app.use(express.json())
 app.use(express.urlencoded({ extended: true }))
+app.use(
+  cors({
+    origin: 'http://localhost:5173', // 替換為你的前端 URL
+    credentials: true, // 允許攜帶憑證（Cookie）
+  })
+)
 app.use(errorHandler)
 app.use('/api', routes)
 

--- a/backend/controllers/user-controller.js
+++ b/backend/controllers/user-controller.js
@@ -42,7 +42,7 @@ const userController = {
   signIn: (req, res, next) => {
     const { email, password } = req.body
 
-    if ((!email, !password)) {
+    if (!email || !password) {
       const err = new Error('請輸入帳號密碼')
       err.statusCode = 400
       return next(err)
@@ -71,6 +71,14 @@ const userController = {
             SECRET,
             { expiresIn: EXPIRES } // 讀取 .env 中的變數
           )
+
+          // 設置 HttpOnly Cookie
+          res.cookie('token', token, {
+            httpOnly: true,
+            secure: process.env.NODE_ENV === 'production',
+            sameSite: 'strict',
+            maxAge: 3600000,
+          })
 
           res.status(200).json({
             message: '登入成功',

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "bcryptjs": "^2.4.3",
+        "cors": "^2.8.5",
         "dotenv": "^16.4.7",
         "express": "^4.21.2",
         "jsonwebtoken": "^9.0.2",
@@ -418,6 +419,19 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
       "license": "MIT"
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -1467,6 +1481,15 @@
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/object-inspect": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -11,6 +11,7 @@
   "description": "",
   "dependencies": {
     "bcryptjs": "^2.4.3",
+    "cors": "^2.8.5",
     "dotenv": "^16.4.7",
     "express": "^4.21.2",
     "jsonwebtoken": "^9.0.2",

--- a/frontend/src/components/LoginForm.jsx
+++ b/frontend/src/components/LoginForm.jsx
@@ -1,7 +1,49 @@
+import { useState } from 'react'
+import { Modal, Button } from 'react-bootstrap'
+
 const RegisterForm = () => {
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [errorMessage, setErrorMessage] = useState('')
+  const [showModal, setShowModal] = useState(false)
+
+  const handleSubmit = async (e) => {
+    e.preventDefault()
+    setErrorMessage('')
+
+    if (!email || !password) {
+      setErrorMessage('請填寫所有欄位')
+      setShowModal(true)
+      return
+    }
+    try {
+      const response = await fetch('http://localhost:3000/api/user/signin', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ email, password }),
+        credentials: 'include', // 啟用 Cookie 傳輸
+      })
+
+      if (!response.ok) {
+        const errorData = await response.json()
+        setErrorMessage(errorData.message || '登入失敗')
+        setShowModal(true)
+        return
+      }
+
+      const data = await response.json()
+      console.log('登入成功', data)
+    } catch (error) {
+      setErrorMessage('伺服器錯誤，請稍後再試')
+      setShowModal(true)
+      console.error('錯誤：', error)
+    }
+  }
   return (
     <div className="form-container">
-      <form>
+      <form onSubmit={handleSubmit}>
         <div className="form-group">
           <label htmlFor="email" className="form-label">
             信箱
@@ -12,6 +54,10 @@ const RegisterForm = () => {
             id="email"
             name="email"
             placeholder="請輸入您的信箱"
+            value={email}
+            onChange={(e) => {
+              setEmail(e.target.value)
+            }}
           />
         </div>
         <div className="form-group">
@@ -24,6 +70,8 @@ const RegisterForm = () => {
             id="password"
             name="password"
             placeholder="請輸入您的密碼"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
           />
         </div>
         <div>
@@ -48,6 +96,18 @@ const RegisterForm = () => {
           </button>
         </div>
       </form>
+      {/* 錯誤訊息彈窗 */}
+      <Modal show={showModal} onHide={() => setShowModal(false)} centered>
+        <Modal.Header closeButton>
+          <Modal.Title>TapTour 登入流程提示</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>{errorMessage}</Modal.Body>
+        <Modal.Footer>
+          <Button variant="secondary" onClick={() => setShowModal(false)}>
+            確定
+          </Button>
+        </Modal.Footer>
+      </Modal>
     </div>
   )
 }


### PR DESCRIPTION
1. Added JWT Token to HttpOnly Cookie for secure storage
2. Configured CORS to support cross-origin requests
3. Implemented fetch in the front-end for login API calls
4. Enabled credentials in fetch to include cookies in requests